### PR TITLE
fix/ util.bytesToSize(post.attachemnt.size) => post.attachment.bytesConversion()

### DIFF
--- a/models/File.js
+++ b/models/File.js
@@ -34,6 +34,13 @@ fileSchema.methods.getFileStream = function(){
   return stream; // 5-5
 };
 
+fileSchema.methods.bytesConversion = function(){
+  var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+  var bytes = this.size;
+  if (bytes == 0) return '0 Byte';
+  var i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
+  return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i];
+}
 
 // model & export
 var File = mongoose.model('file', fileSchema);

--- a/util.js
+++ b/util.js
@@ -79,12 +79,4 @@ util.getPostQueryString = function(req, res, next){
 };
 
 
-util.bytesToSize = function(bytes) { // 1
-   var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-   if (bytes == 0) return '0 Byte';
-   var i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
-   return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i];
-};
-
-
 module.exports = util;

--- a/views/partials/boards/show/card.ejs
+++ b/views/partials/boards/show/card.ejs
@@ -8,7 +8,7 @@
     <div class="col-md-7 col-lg-8 col-xl-9 order-sm-2 order-md-1">
       <% if(post.attachment) { %>
       <div class="ml-2">
-        <!-- 1 --> <small>📁 Attachment: <a href="/files/<%= post.attachment.serverFileName %>/<%= post.attachment.originalFileName %>"><%= post.attachment.originalFileName %></a> (<%= util.bytesToSize(post.attachment.size) %>)</small>
+        <!-- 1 --> <small>📁 Attachment: <a href="/files/<%= post.attachment.serverFileName %>/<%= post.attachment.originalFileName %>"><%= post.attachment.originalFileName %></a> (<%= post.attachment.bytesConversion() %>)</small>
         <br>
         <img src="/files/<%= post.attachment.serverFileName %>/<%= post.attachment.originalFileName %>">
 


### PR DESCRIPTION
 In the post's card, attachment was previously using 'util.bytesToSize(post.attachemnt.size)' to convert bytes, in which 'util' was tossed around by middleware as 'res.locals.util = util' even outside the page, causing inefficiency. Now the util.bytesToSize is moved to File's own method as bytesConversion(), which will return a File's bytes converted into shorthand units. (i.e., KB, MB, etc.)